### PR TITLE
feat: dashboardbox-api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
         <Frame>
           <Routes>
             <Route element={<MainHeader />}>
-              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/dashboard/:userName" element={<Dashboard />} />
               <Route path="/gamelist" element={<GameList />} />
               <Route path="/setting" />
             </Route>

--- a/src/api/GetDashboard.ts
+++ b/src/api/GetDashboard.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import {
+  DashboardError,
+  DashboardResponse,
+} from '../assets/type/GetDashboardPayload';
+import { Axios } from './Axios';
+
+interface GetDashboardProps {
+  userName?: string;
+  callbackFunction: (data: DashboardResponse) => void;
+  handleError: (error: DashboardError) => void;
+}
+
+export const GetDashboard = async ({
+  userName,
+  callbackFunction,
+  handleError,
+}: GetDashboardProps) => {
+  try {
+    const res = await Axios.get(`api/dash-board/${userName}`, {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+      },
+      params: {
+        userName,
+      },
+    });
+
+    callbackFunction(res.data.data);
+  } catch (error) {
+    if (axios.isAxiosError<DashboardError>(error) && error.response) {
+      handleError(error.response.data);
+    }
+  }
+};

--- a/src/assets/component/DashboardBox.tsx
+++ b/src/assets/component/DashboardBox.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 interface DashboardBoxProps {
   title: string;
   img: string;
-  content: string;
-  desc: string;
+  content: string | number;
+  desc?: string;
 }
 
 const DashboardBox = ({ title, img, content, desc }: DashboardBoxProps) => {

--- a/src/assets/component/List.tsx
+++ b/src/assets/component/List.tsx
@@ -10,6 +10,7 @@ interface ListProps {
   listData: ListData[];
   buttonType: 'toggle' | 'navigate';
   selectExercise?: string;
+  isMine?: boolean;
 }
 
 export interface ListData {
@@ -28,6 +29,7 @@ const List = ({
   listData,
   buttonType,
   selectExercise,
+  isMine,
 }: ListProps) => {
   const navbar = useRecoilValue(sidebarState);
 
@@ -41,7 +43,12 @@ const List = ({
       {listData.map(
         (item) =>
           selectExercise === item.exercise && (
-            <ListItem key={item.id} rowData={item} buttonType={buttonType} />
+            <ListItem
+              key={item.id}
+              rowData={item}
+              buttonType={buttonType}
+              isMine={isMine}
+            />
           ),
       )}
     </ListContainer>

--- a/src/assets/component/ListItem.tsx
+++ b/src/assets/component/ListItem.tsx
@@ -7,11 +7,12 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface ListItemProps {
+  isMine?: boolean;
   rowData: ListData;
   buttonType: 'toggle' | 'navigate';
 }
 
-const ListItem = ({ rowData, buttonType }: ListItemProps) => {
+const ListItem = ({ rowData, buttonType, isMine }: ListItemProps) => {
   const navbar = useRecoilValue(sidebarState);
   const navigate = useNavigate();
   const [isParticipated, setIsParticipated] = useState(rowData.status ?? false);
@@ -25,13 +26,17 @@ const ListItem = ({ rowData, buttonType }: ListItemProps) => {
       <ListTitle navbar={navbar}>{rowData.firstContent}</ListTitle>
       <ListSecondTitle>{rowData.secondContent}</ListSecondTitle>
       <ListThirdTitle>{rowData.thirdContent}</ListThirdTitle>
-      {isParticipated ? (
-        <ParticipateText>참여중</ParticipateText>
-      ) : (
-        <SmallButton
-          text={buttonType === 'toggle' ? '참여하기' : '참가하기'}
-          onClick={buttonType === 'toggle' ? toggleButton : handleNavigate}
-        />
+      {isMine && (
+        <>
+          {isParticipated ? (
+            <ParticipateText>참여중</ParticipateText>
+          ) : (
+            <SmallButton
+              text={buttonType === 'toggle' ? '참여하기' : '참가하기'}
+              onClick={buttonType === 'toggle' ? toggleButton : handleNavigate}
+            />
+          )}
+        </>
       )}
     </ListBox>
   );

--- a/src/assets/component/MainHeader.tsx
+++ b/src/assets/component/MainHeader.tsx
@@ -15,11 +15,12 @@ const MainHeader = () => {
 
   const handleLogout = () => {
     navigate('/login');
+    alert('로그아웃 하셨습니다!');
+    localStorage.removeItem('accessToken');
   };
 
   const handleSideBar = () => {
     setNavbar((props) => !props);
-    console.log(navbar);
   };
 
   const handleSubmit = () => {

--- a/src/assets/component/SideBar.tsx
+++ b/src/assets/component/SideBar.tsx
@@ -21,6 +21,7 @@ interface SideBarState {
 
 const SideBar = () => {
   const navigate = useNavigate();
+  const userName = localStorage.getItem('userName');
   const [sideState, setSideState] = useState({
     Dashboard: true,
     Game: false,
@@ -30,7 +31,7 @@ const SideBar = () => {
   const sideComponents: SideBar[] = [
     {
       content: 'Dashboard',
-      path: '/dashboard',
+      path: `/dashboard/${userName}`,
       src: DashBoard,
       state: { Dashboard: true, Game: false, Setting: false },
     },

--- a/src/assets/pages/Dashboard.tsx
+++ b/src/assets/pages/Dashboard.tsx
@@ -5,16 +5,13 @@ import record from '../images/record.svg';
 import SmallButton from '../component/SmallButton';
 import { useEffect, useState } from 'react';
 import List from '../component/List';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { GetDashboard } from '../../api/GetDashboard';
-import {
-  BestRecord,
-  DashboardError,
-  DashboardResponse,
-} from '../type/GetDashboardPayload';
+import { DashboardError, DashboardResponse } from '../type/GetDashboardPayload';
 
 const Dashboard = () => {
   const { userName } = useParams();
+  const navigate = useNavigate();
   const [dashboardRes, setDashboardRes] = useState<DashboardResponse>();
   const [contentView, setContentView] = useState({
     rank: false,
@@ -62,13 +59,14 @@ const Dashboard = () => {
 
   useEffect(() => {
     GetDashboard({ userName, callbackFunction, handleError });
-  }, []);
+  }, [userName]);
 
   const callbackFunction = (data: DashboardResponse) => {
     setDashboardRes(data);
   };
   const handleError = (error: DashboardError) => {
     alert(error.cause);
+    navigate(`/dashboard/${localStorage.getItem('userName')}`);
   };
 
   return (

--- a/src/assets/pages/Dashboard.tsx
+++ b/src/assets/pages/Dashboard.tsx
@@ -3,10 +3,19 @@ import DashboardBox from '../component/DashboardBox';
 import badge from '../images/badge.svg';
 import record from '../images/record.svg';
 import SmallButton from '../component/SmallButton';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import List from '../component/List';
+import { useParams } from 'react-router-dom';
+import { GetDashboard } from '../../api/GetDashboard';
+import {
+  BestRecord,
+  DashboardError,
+  DashboardResponse,
+} from '../type/GetDashboardPayload';
 
 const Dashboard = () => {
+  const { userName } = useParams();
+  const [dashboardRes, setDashboardRes] = useState<DashboardResponse>();
   const [contentView, setContentView] = useState({
     rank: false,
     challenge: true,
@@ -15,27 +24,6 @@ const Dashboard = () => {
     pushup: true,
     squat: false,
   });
-
-  const dashboardBox = [
-    {
-      title: '보유 뱃지',
-      img: badge,
-      content: '5개',
-      desc: '35%달성',
-    },
-    {
-      title: '최고기록',
-      img: record,
-      content: '26개',
-      desc: '스쿼트',
-    },
-    {
-      title: '최고기록',
-      img: record,
-      content: '26개',
-      desc: '푸쉬업',
-    },
-  ];
 
   const RANKDATA = [
     {
@@ -72,78 +60,101 @@ const Dashboard = () => {
     },
   ]);
 
+  useEffect(() => {
+    GetDashboard({ userName, callbackFunction, handleError });
+  }, []);
+
+  const callbackFunction = (data: DashboardResponse) => {
+    setDashboardRes(data);
+  };
+  const handleError = (error: DashboardError) => {
+    alert(error.cause);
+  };
+
   return (
-    <DashboardContainer>
-      <DashboardHeader>
-        <HeaderContent>김정호님 환영해요!</HeaderContent>
-      </DashboardHeader>
-      <DashboardLayout>
-        <DashboardBoxContainer>
-          {dashboardBox.map((item, index) => (
-            <DashboardBox
-              title={item.title}
-              img={item.img}
-              content={item.content}
-              desc={item.desc}
-              key={index}
-            />
-          ))}
-        </DashboardBoxContainer>
-        <ButtonContainer>
-          <SmallButton
-            text="첼린지"
-            onClick={() => setContentView({ rank: false, challenge: true })}
-          />
-          <SmallButton
-            text="랭킹"
-            onClick={() => setContentView({ rank: true, challenge: false })}
-          />
-        </ButtonContainer>
-        {contentView.challenge && (
-          <List
-            title="첼린지"
-            secondTitle="참여자 수"
-            thridTitle="달성현황"
-            listData={challengeData}
-            buttonType="toggle"
-          />
-        )}
-        {contentView.rank && (
-          <ContentContainer>
-            <SelectBox>
-              <SelectExercise
-                state={rankExercise.pushup}
-                onClick={() => {
-                  setRankExercise({ pushup: true, squat: false });
-                }}
-              >
-                푸쉬업
-              </SelectExercise>
-              <SelectExercise
-                state={rankExercise.squat}
-                onClick={() => {
-                  setRankExercise({ pushup: false, squat: true });
-                }}
-              >
-                스쿼트
-              </SelectExercise>
-            </SelectBox>
-            <ContentHeader>
-              <Rank>등수</Rank>
-              <RankName>닉네임</RankName>
-              <RankCount>개수</RankCount>
-            </ContentHeader>
-            {RANKDATA.map((item, index) => (
-              <ContentBox key={index}>
-                <Rank>{item.rank}</Rank>
-                <RankName>{item.name}</RankName>
-                <RankCount>{item.count}</RankCount>
-              </ContentBox>
-            ))}
-          </ContentContainer>
-        )}
-      </DashboardLayout>
-    </DashboardContainer>
+    <>
+      {dashboardRes && (
+        <DashboardContainer>
+          <DashboardHeader>
+            <HeaderContent>{userName}님 환영해요!</HeaderContent>
+          </DashboardHeader>
+          <DashboardLayout>
+            <DashboardBoxContainer>
+              <DashboardBox
+                title="보유 뱃지"
+                img={badge}
+                content={dashboardRes.badgeCount}
+              />
+
+              {dashboardRes.bestRecords.map((item, index) => (
+                <DashboardBox
+                  key={index}
+                  title="최고 기록"
+                  img={record}
+                  content={`${item.record}개`}
+                  desc={item.exerciseName}
+                />
+              ))}
+            </DashboardBoxContainer>
+
+            <ButtonContainer>
+              <SmallButton
+                text="첼린지"
+                onClick={() => setContentView({ rank: false, challenge: true })}
+              />
+              <SmallButton
+                text="랭킹"
+                onClick={() => setContentView({ rank: true, challenge: false })}
+              />
+            </ButtonContainer>
+            {contentView.challenge && (
+              <List
+                title="첼린지"
+                secondTitle="참여자 수"
+                thridTitle="달성현황"
+                listData={challengeData}
+                buttonType="toggle"
+                isMine={dashboardRes.isMine}
+              />
+            )}
+            {contentView.rank && (
+              <ContentContainer>
+                <SelectBox>
+                  <SelectExercise
+                    state={rankExercise.pushup}
+                    onClick={() => {
+                      setRankExercise({ pushup: true, squat: false });
+                    }}
+                  >
+                    푸쉬업
+                  </SelectExercise>
+                  <SelectExercise
+                    state={rankExercise.squat}
+                    onClick={() => {
+                      setRankExercise({ pushup: false, squat: true });
+                    }}
+                  >
+                    스쿼트
+                  </SelectExercise>
+                </SelectBox>
+                <ContentHeader>
+                  <Rank>등수</Rank>
+                  <RankName>닉네임</RankName>
+                  <RankCount>개수</RankCount>
+                </ContentHeader>
+                {RANKDATA.map((item, index) => (
+                  <ContentBox key={index}>
+                    <Rank>{item.rank}</Rank>
+                    <RankName>{item.name}</RankName>
+                    <RankCount>{item.count}</RankCount>
+                  </ContentBox>
+                ))}
+              </ContentContainer>
+            )}
+          </DashboardLayout>
+        </DashboardContainer>
+      )}
+    </>
   );
 };
 

--- a/src/assets/pages/Dashboard.tsx
+++ b/src/assets/pages/Dashboard.tsx
@@ -81,7 +81,8 @@ const Dashboard = () => {
               <DashboardBox
                 title="보유 뱃지"
                 img={badge}
-                content={dashboardRes.badgeCount}
+                content={`${dashboardRes.badgeResponse.badgeCount}개`}
+                desc={`${dashboardRes.badgeResponse.badgePercent}% 달성`}
               />
 
               {dashboardRes.bestRecords.map((item, index) => (

--- a/src/assets/pages/Login/Login.tsx
+++ b/src/assets/pages/Login/Login.tsx
@@ -35,7 +35,7 @@ const Login = () => {
   const callbackFunction = (data: LoginResponse) => {
     alert(data.message);
     localStorage.setItem('accessToken', data.data.accessToken);
-    navigate('/dashboard');
+    navigate(`/dashboard/${data.data.userName}`);
   };
 
   const handleError = (error: LoginError) => {

--- a/src/assets/pages/Login/Login.tsx
+++ b/src/assets/pages/Login/Login.tsx
@@ -18,6 +18,7 @@ export interface LoginInputs {
 
 const Login = () => {
   const navigate = useNavigate();
+
   const {
     register,
     handleSubmit,
@@ -35,6 +36,7 @@ const Login = () => {
   const callbackFunction = (data: LoginResponse) => {
     alert(data.message);
     localStorage.setItem('accessToken', data.data.accessToken);
+    localStorage.setItem('userName', data.data.userName);
     navigate(`/dashboard/${data.data.userName}`);
   };
 

--- a/src/assets/pages/Signup/Validation.tsx
+++ b/src/assets/pages/Signup/Validation.tsx
@@ -3,7 +3,7 @@ export const validation = yup.object().shape({
   userName: yup
     .string()
     .required('닉네임을 다시입력해주세요')
-    .matches(/^(?=.*[a-zA-Z0-9]).{2,10}$/, '닉네임을 다시입력해주세요'),
+    .matches(/^[가-힣a-zA-Z0-9]{2,10}$/, '닉네임을 다시입력해주세요'),
   userId: yup
     .string()
     .required('아이디를 다시입력해주세요')

--- a/src/assets/type/GetDashboardPayload.ts
+++ b/src/assets/type/GetDashboardPayload.ts
@@ -1,8 +1,13 @@
 export interface DashboardResponse {
   userName: string;
-  badgeCount: number;
+  badgeResponse: BadgeResponse;
   bestRecords: BestRecord[];
   isMine: boolean;
+}
+
+interface BadgeResponse {
+  badgeCount: number;
+  badgePercent: number;
 }
 
 export interface DashboardError {

--- a/src/assets/type/GetDashboardPayload.ts
+++ b/src/assets/type/GetDashboardPayload.ts
@@ -1,0 +1,17 @@
+export interface DashboardResponse {
+  userName: string;
+  badgeCount: number;
+  bestRecords: BestRecord[];
+  isMine: boolean;
+}
+
+export interface DashboardError {
+  status: number;
+  code: string;
+  cause: string;
+}
+
+export interface BestRecord {
+  exerciseName: '푸쉬업' | '스쿼트';
+  record: number;
+}

--- a/src/assets/type/PostLoginPayload.ts
+++ b/src/assets/type/PostLoginPayload.ts
@@ -1,11 +1,12 @@
 export interface LoginResponse {
-  data: Token;
+  data: Data;
   message: string;
   status: string;
 }
 
-interface Token {
+interface Data {
   accessToken: string;
+  userName: string;
 }
 
 export interface LoginError {


### PR DESCRIPTION
dashboard-api 구현했습니다 

- [x] dashboard에있는 보유뱃지 및 최고기록 api 연결했습니다
- [x] 로그인 했을때 자기자신의 dashboard로 넘어가게 연결했습니다.
- [x] 자기자신의 dashboard일때만 challengebutton이 보이게 했습니다.
- [x] Header-input에 값을 넣었을때 dashboard로 넘어가는 기능 구현 및 error처리 구현

추가 수정
- [x] signup validation 수정했습니다.
- [x] badge payload가 바껴서 그에 맞게 수정했습니다.
